### PR TITLE
Static typing and spinner fix

### DIFF
--- a/game/objects/note_object.tscn
+++ b/game/objects/note_object.tscn
@@ -1,17 +1,13 @@
 [gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://scripts/note_objects/note.gd" type="Script" id=1]
-[ext_resource path="res://skins/test_skin/taikohitcircleoverlay-0.png" type="Texture" id=2]
-[ext_resource path="res://skins/test_skin/taikobigcircle.png" type="Texture" id=3]
+[ext_resource path="res://skins/test_skin/taikobigcircle.png" type="Texture" id=2]
+[ext_resource path="res://skins/test_skin/taikohitcircleoverlay-0.png" type="Texture" id=3]
 
 [node name="NoteObject" type="KinematicBody2D"]
 script = ExtResource( 1 )
-timing = 3
-speed = 2
-finisher = false
 
 [node name="Sprite" type="TextureRect" parent="."]
-self_modulate = Color( 0.921569, 0.270588, 0.172549, 1 )
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -24,7 +20,7 @@ grow_horizontal = 2
 grow_vertical = 2
 rect_scale = Vector2( 0.56, 0.56 )
 rect_pivot_offset = Vector2( 64.5, 64.5 )
-texture = ExtResource( 3 )
+texture = ExtResource( 2 )
 expand = true
 
 [node name="Overlay" type="TextureRect" parent="Sprite"]
@@ -38,5 +34,5 @@ margin_right = 67.5
 margin_bottom = 67.5
 grow_horizontal = 2
 grow_vertical = 2
-texture = ExtResource( 2 )
+texture = ExtResource( 3 )
 expand = true

--- a/game/objects/roll_object.tscn
+++ b/game/objects/roll_object.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://scripts/note_objects/roll.gd" type="Script" id=1]
-[ext_resource path="res://skins/test_skin/taikohitcircleoverlay-0.png" type="Texture" id=2]
-[ext_resource path="res://skins/test_skin/taikobigcircle.png" type="Texture" id=3]
-[ext_resource path="res://skins/test_skin/taiko-roll-end.png" type="Texture" id=4]
-[ext_resource path="res://skins/test_skin/taiko-roll-middle.png" type="Texture" id=5]
-[ext_resource path="res://skins/test_skin/sliderscorepoint.png" type="Texture" id=6]
+[ext_resource path="res://skins/test_skin/sliderscorepoint.png" type="Texture" id=2]
+[ext_resource path="res://skins/test_skin/taiko-roll-end.png" type="Texture" id=3]
+[ext_resource path="res://skins/test_skin/taiko-roll-middle.png" type="Texture" id=4]
+[ext_resource path="res://skins/test_skin/taikobigcircle.png" type="Texture" id=5]
+[ext_resource path="res://skins/test_skin/taikohitcircleoverlay-0.png" type="Texture" id=6]
 
 [node name="RollObject" type="KinematicBody2D"]
 script = ExtResource( 1 )
@@ -14,7 +14,6 @@ script = ExtResource( 1 )
 rect_scale = Vector2( 0.56, 0.56 )
 
 [node name="Body" type="TextureRect" parent="Scale"]
-modulate = Color( 0.988235, 0.721569, 0.0235294, 1 )
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_top = -64.5
@@ -23,7 +22,7 @@ margin_bottom = 64.5
 grow_horizontal = 2
 grow_vertical = 2
 rect_pivot_offset = Vector2( 0, 64.5 )
-texture = ExtResource( 5 )
+texture = ExtResource( 4 )
 expand = true
 
 [node name="End" type="TextureRect" parent="Scale/Body"]
@@ -34,11 +33,10 @@ margin_right = 66.0
 grow_horizontal = 2
 grow_vertical = 2
 rect_pivot_offset = Vector2( 0, 64.5 )
-texture = ExtResource( 4 )
+texture = ExtResource( 3 )
 expand = true
 
 [node name="Head" type="TextureRect" parent="Scale"]
-self_modulate = Color( 0.988235, 0.721569, 0.0235294, 1 )
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -50,7 +48,7 @@ margin_bottom = 64.5
 grow_horizontal = 2
 grow_vertical = 2
 rect_pivot_offset = Vector2( 64.5, 64.5 )
-texture = ExtResource( 3 )
+texture = ExtResource( 5 )
 expand = true
 
 [node name="Overlay" type="TextureRect" parent="Scale/Head"]
@@ -64,7 +62,7 @@ margin_right = 67.5
 margin_bottom = 67.5
 grow_horizontal = 2
 grow_vertical = 2
-texture = ExtResource( 2 )
+texture = ExtResource( 6 )
 expand = true
 
 [node name="Tick" type="TextureRect" parent="."]
@@ -80,7 +78,7 @@ grow_horizontal = 2
 grow_vertical = 2
 rect_scale = Vector2( 0.56, 0.56 )
 rect_pivot_offset = Vector2( 6.5, 64.5 )
-texture = ExtResource( 6 )
+texture = ExtResource( 2 )
 stretch_mode = 4
 
 [node name="TickContainer" type="Control" parent="."]

--- a/game/objects/spinner_object.tscn
+++ b/game/objects/spinner_object.tscn
@@ -1,18 +1,16 @@
 [gd_scene load_steps=6 format=2]
 
-[ext_resource path="res://scripts/note_objects/spinner.gd" type="Script" id=1]
-[ext_resource path="res://skins/test_skin/spinner-circle.png" type="Texture" id=2]
+[ext_resource path="res://fonts/noto_sans_jp-regular.otf" type="DynamicFontData" id=1]
+[ext_resource path="res://scripts/note_objects/spinner.gd" type="Script" id=2]
 [ext_resource path="res://skins/test_skin/spinner-approachcircle.png" type="Texture" id=3]
-
-[sub_resource type="DynamicFontData" id=2]
-font_path = "res://fonts/noto_sans_jp-regular.otf"
+[ext_resource path="res://skins/test_skin/spinner-circle.png" type="Texture" id=4]
 
 [sub_resource type="DynamicFont" id=1]
 size = 48
-font_data = SubResource( 2 )
+font_data = ExtResource( 1 )
 
 [node name="SpinnerObject" type="KinematicBody2D"]
-script = ExtResource( 1 )
+script = ExtResource( 2 )
 
 [node name="RotationObj" type="Node2D" parent="."]
 
@@ -28,7 +26,7 @@ margin_bottom = 200.0
 grow_horizontal = 2
 grow_vertical = 2
 rect_pivot_offset = Vector2( 200, 200 )
-texture = ExtResource( 2 )
+texture = ExtResource( 4 )
 expand = true
 stretch_mode = 6
 

--- a/game/scenes/gameplay.tscn
+++ b/game/scenes/gameplay.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=43 format=2]
+[gd_scene load_steps=44 format=2]
 
 [ext_resource path="res://scripts/gameplay/chart_loader.gd" type="Script" id=1]
 [ext_resource path="res://skins/test_skin/taikobigcircle.png" type="Texture" id=2]
@@ -29,6 +29,7 @@
 [ext_resource path="res://fonts/noto_sans_jp-black.otf" type="DynamicFontData" id=27]
 [ext_resource path="res://fonts/noto_sans_jp-regular.otf" type="DynamicFontData" id=28]
 [ext_resource path="res://fonts/noto_sans_jp-bold.otf" type="DynamicFontData" id=29]
+[ext_resource path="res://scripts/gameplay.gd" type="Script" id=30]
 
 [sub_resource type="DynamicFont" id=1]
 size = 75
@@ -106,6 +107,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 size_flags_horizontal = 3
 size_flags_vertical = 4
+script = ExtResource( 30 )
 __meta__ = {
 "_edit_vertical_guides_": [ -119.0 ]
 }

--- a/project.godot
+++ b/project.godot
@@ -43,6 +43,11 @@ _global_script_classes=[ {
 "class": "SkinManager",
 "language": "GDScript",
 "path": "res://scripts/global/skin_manager.gd"
+}, {
+"base": "CanvasItem",
+"class": "Spinner",
+"language": "GDScript",
+"path": "res://scripts/note_objects/spinner.gd"
 } ]
 _global_script_class_icons={
 "AudioLoader": "",
@@ -51,7 +56,8 @@ _global_script_class_icons={
 "HitManager": "",
 "Note": "",
 "Roll": "",
-"SkinManager": ""
+"SkinManager": "",
+"Spinner": ""
 }
 
 [application]

--- a/project.godot
+++ b/project.godot
@@ -18,10 +18,16 @@ _global_script_classes=[ {
 "class": "DrumInteraction",
 "language": "GDScript",
 "path": "res://scripts/gameplay/drum_interaction.gd"
+}, {
+"base": "Node",
+"class": "Gameplay",
+"language": "GDScript",
+"path": "res://scripts/gameplay.gd"
 } ]
 _global_script_class_icons={
 "AudioLoader": "",
-"DrumInteraction": ""
+"DrumInteraction": "",
+"Gameplay": ""
 }
 
 [application]

--- a/project.godot
+++ b/project.godot
@@ -13,9 +13,15 @@ _global_script_classes=[ {
 "class": "AudioLoader",
 "language": "GDScript",
 "path": "res://scripts/gd_script_audio_import.gd"
+}, {
+"base": "Node",
+"class": "DrumInteraction",
+"language": "GDScript",
+"path": "res://scripts/gameplay/drum_interaction.gd"
 } ]
 _global_script_class_icons={
-"AudioLoader": ""
+"AudioLoader": "",
+"DrumInteraction": ""
 }
 
 [application]

--- a/project.godot
+++ b/project.godot
@@ -24,10 +24,20 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://scripts/gameplay.gd"
 }, {
+"base": "Node",
+"class": "HitManager",
+"language": "GDScript",
+"path": "res://scripts/gameplay/hit_manager.gd"
+}, {
 "base": "KinematicBody2D",
 "class": "Note",
 "language": "GDScript",
 "path": "res://scripts/note_objects/note.gd"
+}, {
+"base": "KinematicBody2D",
+"class": "Roll",
+"language": "GDScript",
+"path": "res://scripts/note_objects/roll.gd"
 }, {
 "base": "Reference",
 "class": "SkinManager",
@@ -38,7 +48,9 @@ _global_script_class_icons={
 "AudioLoader": "",
 "DrumInteraction": "",
 "Gameplay": "",
+"HitManager": "",
 "Note": "",
+"Roll": "",
 "SkinManager": ""
 }
 

--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://scripts/gameplay.gd"
 }, {
+"base": "KinematicBody2D",
+"class": "Note",
+"language": "GDScript",
+"path": "res://scripts/note_objects/note.gd"
+}, {
 "base": "Reference",
 "class": "SkinManager",
 "language": "GDScript",
@@ -33,6 +38,7 @@ _global_script_class_icons={
 "AudioLoader": "",
 "DrumInteraction": "",
 "Gameplay": "",
+"Note": "",
 "SkinManager": ""
 }
 

--- a/project.godot
+++ b/project.godot
@@ -23,11 +23,17 @@ _global_script_classes=[ {
 "class": "Gameplay",
 "language": "GDScript",
 "path": "res://scripts/gameplay.gd"
+}, {
+"base": "Reference",
+"class": "SkinManager",
+"language": "GDScript",
+"path": "res://scripts/global/skin_manager.gd"
 } ]
 _global_script_class_icons={
 "AudioLoader": "",
 "DrumInteraction": "",
-"Gameplay": ""
+"Gameplay": "",
+"SkinManager": ""
 }
 
 [application]
@@ -40,7 +46,6 @@ config/icon="res://icon.png"
 
 settings="*res://scripts/global/global_settings.gd"
 tools="*res://scripts/global/global_tools.gd"
-skin="*res://scripts/global/skin_manager.gd"
 
 [display]
 

--- a/scripts/gameplay.gd
+++ b/scripts/gameplay.gd
@@ -1,6 +1,8 @@
 class_name Gameplay
 extends Node
 
+var skin := SkinManager.new()
+
 onready var _drum_visual := $"BarLeft/DrumVisual" as Node
 onready var l_don_obj := _drum_visual.get_node("LeftDon") as CanvasItem
 onready var l_kat_obj := _drum_visual.get_node("LeftKat") as CanvasItem

--- a/scripts/gameplay.gd
+++ b/scripts/gameplay.gd
@@ -13,3 +13,6 @@ onready var _judgements := $"BarRight/HitPointOffset/Judgements" as Node
 onready var accurate_obj := _judgements.get_node("JudgeAccurate") as CanvasItem
 onready var inaccurate_obj := _judgements.get_node("JudgeInaccurate") as CanvasItem
 onready var miss_obj := _judgements.get_node("JudgeMiss") as CanvasItem
+
+onready var hit_manager := $"HitManager" as HitManager
+onready var music := $"Music" as AudioStreamPlayer

--- a/scripts/gameplay.gd
+++ b/scripts/gameplay.gd
@@ -1,0 +1,13 @@
+class_name Gameplay
+extends Node
+
+onready var _drum_visual := $"BarLeft/DrumVisual" as Node
+onready var l_don_obj := _drum_visual.get_node("LeftDon") as CanvasItem
+onready var l_kat_obj := _drum_visual.get_node("LeftKat") as CanvasItem
+onready var r_don_obj := _drum_visual.get_node("RightDon") as CanvasItem
+onready var r_kat_obj := _drum_visual.get_node("RightKat") as CanvasItem
+
+onready var _judgements := $"BarRight/HitPointOffset/Judgements" as Node
+onready var accurate_obj := _judgements.get_node("JudgeAccurate") as CanvasItem
+onready var inaccurate_obj := _judgements.get_node("JudgeInaccurate") as CanvasItem
+onready var miss_obj := _judgements.get_node("JudgeMiss") as CanvasItem

--- a/scripts/gameplay/chart_loader.gd
+++ b/scripts/gameplay/chart_loader.gd
@@ -113,7 +113,6 @@ func loadAndProcessAll(filePath) -> void:
 
 		#figure out what kind of note it is
 		#osu keeps type as an int that references bytes
-		var gameplay := $".." as Gameplay
 		
 		if 1 << 3 & int(noteData[3]): # spinner
 			note["_noteType"] = 2
@@ -144,7 +143,7 @@ func loadAndProcessAll(filePath) -> void:
 				note["length"] = (((osupx * repeats) / (140 * svData[1]) * abs(beatLength)) / 1000)
 
 				var noteObject = rollObj.instance()
-				noteObject.changeProperties(note["time"], totalcurSV, note["finisher"], note["length"], curSVData[0], gameplay.skin)
+				noteObject.change_properties(note["time"], totalcurSV, note["length"], note["finisher"], curSVData[0])
 				objContainer.get_node("EtcContainer").add_child(noteObject)
 				objContainer.get_node("EtcContainer").move_child(noteObject, 0)
 

--- a/scripts/gameplay/chart_loader.gd
+++ b/scripts/gameplay/chart_loader.gd
@@ -151,7 +151,7 @@ func loadAndProcessAll(filePath) -> void:
 			else: #normal note
 				note["_noteType"] = int(bool(((1 << 1) + (1 << 3)) & int(noteData[4])))
 				var noteObject = noteObj.instance()
-				noteObject.change_properties(note["time"], totalcurSV, gameplay.skin, note["_noteType"], note["finisher"])
+				noteObject.change_properties(note["time"], totalcurSV, note["_noteType"], note["finisher"])
 				objContainer.get_node("NoteContainer").add_child(noteObject)
 				objContainer.get_node("NoteContainer").move_child(noteObject, 0)
 

--- a/scripts/gameplay/chart_loader.gd
+++ b/scripts/gameplay/chart_loader.gd
@@ -151,7 +151,7 @@ func loadAndProcessAll(filePath) -> void:
 			else: #normal note
 				note["_noteType"] = int(bool(((1 << 1) + (1 << 3)) & int(noteData[4])))
 				var noteObject = noteObj.instance()
-				noteObject.changeProperties(note["time"], totalcurSV, note["_noteType"], note["finisher"], gameplay.skin)
+				noteObject.change_properties(note["time"], totalcurSV, gameplay.skin, note["_noteType"], note["finisher"])
 				objContainer.get_node("NoteContainer").add_child(noteObject)
 				objContainer.get_node("NoteContainer").move_child(noteObject, 0)
 

--- a/scripts/gameplay/chart_loader.gd
+++ b/scripts/gameplay/chart_loader.gd
@@ -113,6 +113,7 @@ func loadAndProcessAll(filePath) -> void:
 
 		#figure out what kind of note it is
 		#osu keeps type as an int that references bytes
+		var gameplay := $".." as Gameplay
 		
 		if 1 << 3 & int(noteData[3]): # spinner
 			note["_noteType"] = 2
@@ -143,14 +144,14 @@ func loadAndProcessAll(filePath) -> void:
 				note["length"] = (((osupx * repeats) / (140 * svData[1]) * abs(beatLength)) / 1000)
 
 				var noteObject = rollObj.instance()
-				noteObject.changeProperties(note["time"], totalcurSV, note["finisher"], note["length"], curSVData[0])
+				noteObject.changeProperties(note["time"], totalcurSV, note["finisher"], note["length"], curSVData[0], gameplay.skin)
 				objContainer.get_node("EtcContainer").add_child(noteObject)
 				objContainer.get_node("EtcContainer").move_child(noteObject, 0)
 
 			else: #normal note
 				note["_noteType"] = int(bool(((1 << 1) + (1 << 3)) & int(noteData[4])))
 				var noteObject = noteObj.instance()
-				noteObject.changeProperties(note["time"], totalcurSV, note["_noteType"], note["finisher"])
+				noteObject.changeProperties(note["time"], totalcurSV, note["_noteType"], note["finisher"], gameplay.skin)
 				objContainer.get_node("NoteContainer").add_child(noteObject)
 				objContainer.get_node("NoteContainer").move_child(noteObject, 0)
 

--- a/scripts/gameplay/drum_interaction.gd
+++ b/scripts/gameplay/drum_interaction.gd
@@ -1,60 +1,75 @@
+class_name DrumInteraction
 extends Node
 
-onready var lDonObj = get_node("../BarLeft/DrumVisual/LeftDon")
-onready var rDonObj = get_node("../BarLeft/DrumVisual/RightDon")
-onready var lKatObj = get_node("../BarLeft/DrumVisual/LeftKat")
-onready var rKatObj = get_node("../BarLeft/DrumVisual/RightKat")
+onready var f_don_aud := $"FinisherDonAudio" as AudioStreamPlayer
+onready var f_kat_aud := $"FinisherKatAudio" as AudioStreamPlayer
+onready var l_don_aud := $"LeftDonAudio" as AudioStreamPlayer
+onready var l_kat_aud := $"LeftKatAudio" as AudioStreamPlayer
+onready var r_don_aud := $"RightDonAudio" as AudioStreamPlayer
+onready var r_kat_aud := $"RightKatAudio" as AudioStreamPlayer
 
-onready var lDonAud = get_node("LeftDonAudio")
-onready var rDonAud = get_node("RightDonAudio")
-onready var rKatAud = get_node("RightKatAudio")
-onready var lKatAud = get_node("LeftKatAudio")
+onready var _l_don_obj := $"../BarLeft/DrumVisual/LeftDon" as CanvasItem
+onready var _l_kat_obj := $"../BarLeft/DrumVisual/LeftKat" as CanvasItem
+onready var _r_don_obj := $"../BarLeft/DrumVisual/RightDon" as CanvasItem
+onready var _r_kat_obj := $"../BarLeft/DrumVisual/RightKat" as CanvasItem
 
-onready var accurateObj = get_node("../BarRight/HitPointOffset/Judgements/JudgeAccurate")
-onready var inaccurateObj = get_node("../BarRight/HitPointOffset/Judgements/JudgeInaccurate")
-onready var missObj = get_node("../BarRight/HitPointOffset/Judgements/JudgeMiss")
+onready var _accurate_obj := $"../BarRight/HitPointOffset/Judgements/JudgeAccurate" as CanvasItem
+onready var _inaccurate_obj := $"../BarRight/HitPointOffset/Judgements/JudgeInccurate" as CanvasItem
+onready var _miss_obj := $"../BarRight/HitPointOffset/Judgements/JudgeMiss" as CanvasItem
 
-onready var tween = get_node("DrumAnimationTween")
+onready var _tween := $"DrumAnimationTween" as Tween
 
-func _input(_ev) -> void:
-	if Input.is_action_just_pressed("LeftDon"): 
-		keypressAnimation(1)
-	if Input.is_action_just_pressed("RightDon"): 
-		keypressAnimation(2)
-	if Input.is_action_just_pressed("LeftKat"): 
-		keypressAnimation(3)
-	if Input.is_action_just_pressed("RightKat"): 
-		keypressAnimation(4)
 
-func keypressAnimation(key) -> void:
-	var obj
-	match key:
-		1: 
-			obj = lDonObj
-			lDonAud.play()
-		2: 
-			obj = rDonObj 
-			rDonAud.play()
-		3: 
-			obj = lKatObj
-			lKatAud.play()
-		4:
-			obj = rKatObj
-			rKatAud.play()
-	
-	tween.interpolate_property(obj, "self_modulate",
-		Color(1,1,1,1), Color(1,1,1,0), 0.2,
-		Tween.TRANS_LINEAR, Tween.EASE_OUT)
-	tween.start()
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("LeftDon"):
+		keypress_animation(1)
+	if event.is_action_pressed("RightDon"):
+		keypress_animation(2)
+	if event.is_action_pressed("LeftKat"):
+		keypress_animation(3)
+	if event.is_action_pressed("RightKat"):
+		keypress_animation(4)
 
-func hitNotifyAnimation(type) -> void:
-	var obj
+
+func hit_notify_animation(type: String) -> void:
+	var obj: CanvasItem
 	match type:
-		"accurate":   obj = accurateObj
-		"inaccurate": obj = inaccurateObj
-		"miss":       obj = missObj
+		"accurate":
+			obj = _accurate_obj
+		"innacurate":
+			obj = _inaccurate_obj
+		"miss":
+			obj = _miss_obj
+		_:
+			push_warning("Unknown hit animation")
+			return
 
-	tween.interpolate_property(obj, "self_modulate",
-		Color(1,1,1,1), Color(1,1,1,0), 0.4,
-		Tween.TRANS_LINEAR, Tween.EASE_OUT)
-	tween.start()
+	if not _tween.interpolate_property(obj, "self_modulate", Color.white, Color.transparent, 0.4, Tween.TRANS_LINEAR, Tween.EASE_OUT):
+		push_warning("Attempted to tween hit animation.")
+	if not _tween.start():
+		push_warning("Attempted to start hit animation tween.")
+
+
+func keypress_animation(key: int) -> void:
+	var obj: CanvasItem
+	match key:
+		1:
+			obj = _l_don_obj
+			l_don_aud.play()
+		2:
+			obj = _r_don_obj
+			r_don_aud.play()
+		3:
+			obj = _l_kat_obj
+			l_kat_aud.play()
+		4:
+			obj = _r_kat_obj
+			r_kat_aud.play()
+		_:
+			push_warning("Unknown keypress animation.")
+			return
+
+	if not _tween.interpolate_property(obj, "self_modulate", Color.white, Color.transparent, 0.2, Tween.TRANS_LINEAR, Tween.EASE_OUT):
+		push_warning("Attempted to tween keypress animation.")
+	if not _tween.start():
+		push_warning("Attempted to start keypress animation tween.")

--- a/scripts/gameplay/drum_interaction.gd
+++ b/scripts/gameplay/drum_interaction.gd
@@ -8,14 +8,7 @@ onready var l_kat_aud := $"LeftKatAudio" as AudioStreamPlayer
 onready var r_don_aud := $"RightDonAudio" as AudioStreamPlayer
 onready var r_kat_aud := $"RightKatAudio" as AudioStreamPlayer
 
-onready var _l_don_obj := $"../BarLeft/DrumVisual/LeftDon" as CanvasItem
-onready var _l_kat_obj := $"../BarLeft/DrumVisual/LeftKat" as CanvasItem
-onready var _r_don_obj := $"../BarLeft/DrumVisual/RightDon" as CanvasItem
-onready var _r_kat_obj := $"../BarLeft/DrumVisual/RightKat" as CanvasItem
-
-onready var _accurate_obj := $"../BarRight/HitPointOffset/Judgements/JudgeAccurate" as CanvasItem
-onready var _inaccurate_obj := $"../BarRight/HitPointOffset/Judgements/JudgeInccurate" as CanvasItem
-onready var _miss_obj := $"../BarRight/HitPointOffset/Judgements/JudgeMiss" as CanvasItem
+onready var _gameplay := self.get_parent() as Gameplay
 
 onready var _tween := $"DrumAnimationTween" as Tween
 
@@ -35,11 +28,11 @@ func hit_notify_animation(type: String) -> void:
 	var obj: CanvasItem
 	match type:
 		"accurate":
-			obj = _accurate_obj
+			obj = _gameplay.accurate_obj
 		"innacurate":
-			obj = _inaccurate_obj
+			obj = _gameplay.inaccurate_obj
 		"miss":
-			obj = _miss_obj
+			obj = _gameplay.miss_obj
 		_:
 			push_warning("Unknown hit animation")
 			return
@@ -54,16 +47,16 @@ func keypress_animation(key: int) -> void:
 	var obj: CanvasItem
 	match key:
 		1:
-			obj = _l_don_obj
+			obj = _gameplay.l_don_obj
 			l_don_aud.play()
 		2:
-			obj = _r_don_obj
+			obj = _gameplay.r_don_obj
 			r_don_aud.play()
 		3:
-			obj = _l_kat_obj
+			obj = _gameplay.l_kat_obj
 			l_kat_aud.play()
 		4:
-			obj = _r_kat_obj
+			obj = _gameplay.r_kat_obj
 			r_kat_aud.play()
 		_:
 			push_warning("Unknown keypress animation.")

--- a/scripts/gameplay/drum_interaction.gd
+++ b/scripts/gameplay/drum_interaction.gd
@@ -8,7 +8,7 @@ onready var l_kat_aud := $"LeftKatAudio" as AudioStreamPlayer
 onready var r_don_aud := $"RightDonAudio" as AudioStreamPlayer
 onready var r_kat_aud := $"RightKatAudio" as AudioStreamPlayer
 
-onready var _gameplay := self.get_parent() as Gameplay
+onready var _gameplay := $".." as Gameplay
 
 onready var _tween := $"DrumAnimationTween" as Tween
 

--- a/scripts/gameplay/drum_interaction.gd
+++ b/scripts/gameplay/drum_interaction.gd
@@ -29,7 +29,7 @@ func hit_notify_animation(type: String) -> void:
 	match type:
 		"accurate":
 			obj = _gameplay.accurate_obj
-		"innacurate":
+		"inaccurate":
 			obj = _gameplay.inaccurate_obj
 		"miss":
 			obj = _gameplay.miss_obj

--- a/scripts/gameplay/hit_error.gd
+++ b/scripts/gameplay/hit_error.gd
@@ -15,10 +15,11 @@ func newMarker(type, timing):
 	hitPoints.add_child(newMarker)
 	
 	var markerColour: Color;
+	var gameplay := $"../.." as Gameplay
 	match type:
-		"accurate": markerColour = skin.AccurateColour
-		"inaccurate": markerColour = skin.InaccurateColour
-		"miss": markerColour = skin.MissColour
+		"accurate": markerColour = gameplay.skin.accurate_colour
+		"inaccurate": markerColour = gameplay.skin.inaccurate_colour
+		"miss": markerColour = gameplay.skin.miss_colour
 	newMarker.modulate = markerColour;
 	
 	newMarker.rect_position = Vector2(timing * self.rect_size.x * 3.2 + (self.rect_size.x / 2), 0)

--- a/scripts/gameplay/hit_manager.gd
+++ b/scripts/gameplay/hit_manager.gd
@@ -55,14 +55,14 @@ func _process(_delta) -> void:
 			
 			if !nextNoteIsKat:
 				if lastSideUsedIsRight: #kDdk
-					drumInteraction.keypressAnimation(1)
+					drumInteraction.keypress_animation(1)
 				else: #kdDk
-					drumInteraction.keypressAnimation(2)
+					drumInteraction.keypress_animation(2)
 			else:
 				if lastSideUsedIsRight: #Kddk
-					drumInteraction.keypressAnimation(3)
+					drumInteraction.keypress_animation(3)
 				else: #kddK
-					drumInteraction.keypressAnimation(4)
+					drumInteraction.keypress_animation(4)
 			lastSideUsedIsRight = !lastSideUsedIsRight
 		
 		#miss check
@@ -122,16 +122,16 @@ func addScore(type) -> void:
 			score += int(300.0 * scoreMultiplier)
 			accurateCount += 1
 			combo += 1
-			drumInteraction.hitNotifyAnimation("accurate");
+			drumInteraction.hit_notify_animation("accurate");
 		"inaccurate":
 			score += int(150.0 * scoreMultiplier)
 			inaccurateCount += 1
 			combo += 1
-			drumInteraction.hitNotifyAnimation("inaccurate");
+			drumInteraction.hit_notify_animation("inaccurate");
 		"miss":
 			missCount += 1
 			combo = 0
-			drumInteraction.hitNotifyAnimation("miss");
+			drumInteraction.hit_notify_animation("miss");
 		"finisher":
 			score += int(300.0 * scoreMultiplier)
 		"spinner":

--- a/scripts/gameplay/hit_manager.gd
+++ b/scripts/gameplay/hit_manager.gd
@@ -48,7 +48,7 @@ func _process(_delta) -> void:
 		#temp auto
 		#doesnt support special note types currently
 		if (auto && ((chart.curTime + settings.globalOffset) - objContainer.get_node("NoteContainer").get_child(objContainer.get_node("NoteContainer").get_child_count() - nextHittableNote - 1).timing) > 0):
-			var nextNoteIsKat = objContainer.get_node("NoteContainer").get_child(objContainer.get_node("NoteContainer").get_child_count() - nextHittableNote - 1).isKat
+			var nextNoteIsKat = objContainer.get_node("NoteContainer").get_child(objContainer.get_node("NoteContainer").get_child_count() - nextHittableNote - 1).is_kat
 			
 			if lastSideUsedIsRight == null: lastSideUsedIsRight = true
 			checkInput(nextNoteIsKat, lastSideUsedIsRight)
@@ -77,7 +77,7 @@ func checkInput(isKat, isRight) -> void:
 	if chart.curPlaying:
 		if (lastNoteWasFinisher):
 			var lastNote = objContainer.get_node("NoteContainer").get_child(objContainer.get_node("NoteContainer").get_child_count() - nextHittableNote);
-			if (abs((curTime - lastNote.timing) + settings.globalOffset)  <= accTiming && lastNote.isKat == isKat) && (lastSideUsedIsRight != isRight):
+			if (abs((curTime - lastNote.timing) + settings.globalOffset)  <= accTiming && lastNote.is_kat == isKat) && (lastSideUsedIsRight != isRight):
 				#swallow input, give more points
 				addScore("finisher")
 				if isKat: fKatAud.play()
@@ -92,10 +92,10 @@ func checkInput(isKat, isRight) -> void:
 			
 			if (abs((curTime - nextNote.timing) + settings.globalOffset) <= inaccTiming):
 				#check if accurate and right key pressed
-				if (abs((curTime - nextNote.timing) + settings.globalOffset) <= accTiming && nextNote.isKat == isKat):
+				if (abs((curTime - nextNote.timing) + settings.globalOffset) <= accTiming && nextNote.is_kat == isKat):
 					hitType = "accurate"
 				#check if inaccurate and right key pressed
-				elif (nextNote.isKat == isKat): 
+				elif (nextNote.is_kat == isKat): 
 					hitType = "inaccurate"
 				
 				#broken for some reason, not really sure whats wrong. ill look at it later

--- a/scripts/gameplay/hit_manager.gd
+++ b/scripts/gameplay/hit_manager.gd
@@ -1,3 +1,4 @@
+class_name HitManager
 extends Node
 
 onready var music = get_node("../Music")

--- a/scripts/global/skin_manager.gd
+++ b/scripts/global/skin_manager.gd
@@ -1,9 +1,9 @@
-extends Node
+class_name SkinManager
 
-var DonColour = Color("EB452C");
-var KatColour = Color("438EAC");
-var RollColour = Color("FCB806");
+var don_colour := Color("eb452c");
+var kat_colour := Color("438eac");
+var roll_colour := Color("fcb806");
 
-var AccurateColour = Color("52A6FF");
-var InaccurateColour = Color("79DA5E");
-var MissColour = Color("C74B4B");
+var accurate_colour := Color("52a6ff");
+var inaccurate_colour := Color("79da5e");
+var miss_colour := Color("c74b4b");

--- a/scripts/note_objects/note.gd
+++ b/scripts/note_objects/note.gd
@@ -1,37 +1,55 @@
+class_name Note
 extends KinematicBody2D
 
-export var timing = 0
-export var speed = 1
+var finisher := true
+var is_kat := false
+var timing := 0.0
 
-export var finisher = true
-export var isKat = false
-export var active = false
+var _active := false
+var _skin := SkinManager.new()
+var _speed := 1.0
 
-var vel: Vector2
 
-func _process(_delta) -> void:
+func _ready() -> void:
+	var sprite := $"Sprite" as TextureRect
+
+	# finisher scale
+	if finisher:
+		sprite.rect_scale = Vector2(0.9, 0.9)
+
+	# note colour
+	sprite.self_modulate = _skin.kat_colour if is_kat else _skin.don_colour
+
+
+func _process(_delta: float) -> void:
 	# move note if not hit yet
-	if active: vel = move_and_slide(Vector2((speed * -1.9), 0))
+	if _active:
+		var _vel := move_and_slide(Vector2(_speed * -1.9, 0))
 
-func changeProperties(newTiming, newSpeed, newIsKat, newFinisher, skin):
-	timing = newTiming
-	speed = newSpeed
-	
-	#finisher scale
-	finisher = newFinisher
-	if(finisher): get_child(0).rect_scale = Vector2(0.9,0.9)
-	
-	#note colour
-	if (newIsKat == 1): isKat = true
-	else: isKat = false
-	if(isKat): get_child(0).self_modulate = skin.kat_colour
-	else:      get_child(0).self_modulate = skin.don_colour
+
+func change_properties(new_timing: float, new_speed: float, new_skin: SkinManager, new_is_kat: bool, new_finisher: bool) -> void:
+	if _active:
+		push_warning("Attempted to change note properties after active.")
+		return
+	finisher = new_finisher
+	is_kat = new_is_kat
+	timing = new_timing
+	_skin = new_skin
+	_speed = new_speed
+
 
 func activate() -> void:
-	modulate = Color(1,1,1,1)
-	position = Vector2(timing * speed, 0)
-	active = true
+	if _active:
+		push_warning("Attempted to activate after active.")
+		return
+	modulate = Color.white
+	position = Vector2(_speed * timing, 0)
+	_active = true
+
 
 func deactivate() -> void:
-	modulate = Color(0,0,0,0)
-	active = false
+	if not _active:
+		push_warning("Attempted to deactivate before active.")
+		return
+	modulate = Color.transparent
+	_active = false

--- a/scripts/note_objects/note.gd
+++ b/scripts/note_objects/note.gd
@@ -6,8 +6,9 @@ var is_kat := false
 var timing := 0.0
 
 var _active := false
-var _skin := SkinManager.new()
 var _speed := 1.0
+
+onready var _gameplay := $"../../../../.." as Gameplay
 
 
 func _ready() -> void:
@@ -18,7 +19,7 @@ func _ready() -> void:
 		sprite.rect_scale = Vector2(0.9, 0.9)
 
 	# note colour
-	sprite.self_modulate = _skin.kat_colour if is_kat else _skin.don_colour
+	sprite.self_modulate = _gameplay.skin.kat_colour if is_kat else _gameplay.skin.don_colour
 
 
 func _process(_delta: float) -> void:
@@ -27,14 +28,13 @@ func _process(_delta: float) -> void:
 		var _vel := move_and_slide(Vector2(_speed * -1.9, 0))
 
 
-func change_properties(new_timing: float, new_speed: float, new_skin: SkinManager, new_is_kat: bool, new_finisher: bool) -> void:
+func change_properties(new_timing: float, new_speed: float, new_is_kat: bool, new_finisher: bool) -> void:
 	if _active:
 		push_warning("Attempted to change note properties after active.")
 		return
 	finisher = new_finisher
 	is_kat = new_is_kat
 	timing = new_timing
-	_skin = new_skin
 	_speed = new_speed
 
 

--- a/scripts/note_objects/note.gd
+++ b/scripts/note_objects/note.gd
@@ -13,7 +13,7 @@ func _process(_delta) -> void:
 	# move note if not hit yet
 	if active: vel = move_and_slide(Vector2((speed * -1.9), 0))
 
-func changeProperties(newTiming, newSpeed, newIsKat, newFinisher):
+func changeProperties(newTiming, newSpeed, newIsKat, newFinisher, skin):
 	timing = newTiming
 	speed = newSpeed
 	
@@ -24,8 +24,8 @@ func changeProperties(newTiming, newSpeed, newIsKat, newFinisher):
 	#note colour
 	if (newIsKat == 1): isKat = true
 	else: isKat = false
-	if(isKat): get_child(0).self_modulate = skin.KatColour
-	else:      get_child(0).self_modulate = skin.DonColour
+	if(isKat): get_child(0).self_modulate = skin.kat_colour
+	else:      get_child(0).self_modulate = skin.don_colour
 
 func activate() -> void:
 	modulate = Color(1,1,1,1)

--- a/scripts/note_objects/note.gd
+++ b/scripts/note_objects/note.gd
@@ -40,7 +40,7 @@ func change_properties(new_timing: float, new_speed: float, new_is_kat: bool, ne
 
 func activate() -> void:
 	if _active:
-		push_warning("Attempted to activate after active.")
+		push_warning("Attempted to activate note after active.")
 		return
 	modulate = Color.white
 	position = Vector2(_speed * timing, 0)
@@ -49,7 +49,7 @@ func activate() -> void:
 
 func deactivate() -> void:
 	if not _active:
-		push_warning("Attempted to deactivate before active.")
+		push_warning("Attempted to deactivate note before active.")
 		return
 	modulate = Color.transparent
 	_active = false

--- a/scripts/note_objects/roll.gd
+++ b/scripts/note_objects/roll.gd
@@ -19,7 +19,7 @@ var vel: Vector2
 
 #will need to be cleaned, some values arent used other than this func so i should get rid
 #of the "new" part of it
-func changeProperties(newTiming, newSpeed, newFinisher, newLength, beatlength):
+func changeProperties(newTiming, newSpeed, newFinisher, newLength, beatlength, skin):
 	timing = newTiming
 	speed = newSpeed
 	length = newLength
@@ -29,8 +29,8 @@ func changeProperties(newTiming, newSpeed, newFinisher, newLength, beatlength):
 	if(finisher): get_child(0).rect_scale = Vector2(0.9,0.9)
 	
 	#note colour
-	get_node("Scale/Head").self_modulate = skin.RollColour
-	get_node("Scale/Body").modulate = skin.RollColour
+	get_node("Scale/Head").self_modulate = skin.roll_colour
+	get_node("Scale/Body").modulate = skin.roll_colour
 	
 	get_node("Scale/Body").rect_size = Vector2(speed * length, 129)
 	

--- a/scripts/note_objects/roll.gd
+++ b/scripts/note_objects/roll.gd
@@ -1,90 +1,109 @@
+class_name Roll
 extends KinematicBody2D
 
-onready var hitManager = get_node("../../../../../HitManager")
+var finisher := true
+var timing := 0.0
 
-export var timing = 0
-export var speed = 1
-export var length = 1
+var _active := false
+var _length := 1.0
+var _speed := 1.0
 
-export var finisher = true
-export var active = false
+var _current_tick := 0
+var _tick_distance := 0.0
+var _total_ticks := 0
 
-var totalTicks: int = 0
-var currentTick: int = 0
-var tickDistance: float = 0
+onready var _gameplay := $"../../../../.." as Gameplay
+onready var _tick_container := $"TickContainer"
 
-var curSongTime: float = 0
 
-var vel: Vector2
+func _ready() -> void:
+	var scale := $"Scale" as Control
 
-#will need to be cleaned, some values arent used other than this func so i should get rid
-#of the "new" part of it
-func changeProperties(newTiming, newSpeed, newFinisher, newLength, beatlength, skin):
-	timing = newTiming
-	speed = newSpeed
-	length = newLength
-	
-	#finisher scale
-	finisher = newFinisher
-	if(finisher): get_child(0).rect_scale = Vector2(0.9,0.9)
-	
-	#note colour
-	get_node("Scale/Head").self_modulate = skin.roll_colour
-	get_node("Scale/Body").modulate = skin.roll_colour
-	
-	get_node("Scale/Body").rect_size = Vector2(speed * length, 129)
-	
-	tickDistance = beatlength / 100
-	
-	totalTicks = floor(length / tickDistance * 48.0)
-	#length of the roll divided by the distance between ticks
-	#and multiplied by the frequency
-	
-	#haha funny !!! idx like iidx as in funny beatmania silly game keys
-	# but its alos like INDEX!!!!!!!!!!!!!!!
-	#GET IT
-	for tickIdx in totalTicks:
-		#duplicate base tick and put it on the tick container
-		var newTick = get_child(1).duplicate() 
-		get_node("TickContainer").add_child(newTick)
-		get_node("TickContainer").move_child(newTick, get_node("TickContainer").get_child_count())
-		
-		#newTick.rect_position = Vector2( (tickIdx * (tickDistance * 4)) * (speed / 1000) * 40, -64.5)
-		newTick.rect_position = Vector2( tickIdx * (tickDistance / 40) * speed , -64.5)
-		#(the number of tick * (tick distance * time signature)) * (note speed / 1000) * (time signature * 10)
+	# finisher scale
+	if finisher:
+		scale.rect_scale = Vector2(0.9, 0.9)
 
-func _input(_ev) -> void:
-	if (totalTicks > currentTick && active):
-		#lol
-		if Input.is_action_just_pressed("LeftDon") || Input.is_action_just_pressed("RightDon") || Input.is_action_just_pressed("LeftKat") || Input.is_action_just_pressed("RightKat"):
-			
-			if curSongTime > timing + length + hitManager.inaccTiming: #if after slider is hittable
-				active = false
-			elif curSongTime < timing - hitManager.inaccTiming: #if before slider is hittable
-				pass
-			
-			else:
-				#get current tick target
-				currentTick = floor((curSongTime - timing) * (tickDistance * 4))
-				if currentTick < 0: currentTick = 0
-				elif currentTick > totalTicks: currentTick = totalTicks
-				
-				if(get_node("TickContainer").get_child_count() - 1 < currentTick): currentTick = get_node("TickContainer").get_child_count() - 1
-				if get_node("TickContainer").get_child(currentTick).visible:
-					print(currentTick)
-					get_node("TickContainer").get_child(currentTick).set_visible(false)
-					hitManager.addScore("roll")
+	# note colour
+	(scale.get_node("Head") as CanvasItem).self_modulate = _gameplay.skin.roll_colour
 
-func _process(_delta):
-	if active: vel = move_and_slide(Vector2((speed * -1.9), 0))
-	#this feels dumb too idk...
-	curSongTime = get_node("../../../../../Music").get_playback_position()
+	var body := scale.get_node("Body") as Control
+	body.modulate = _gameplay.skin.roll_colour
+	body.rect_size = Vector2(_speed * _length, 129)
 
-func activate():
-	position = Vector2(timing * speed, 0)
-	for tick in get_node("TickContainer").get_children():
-		tick.set_visible(true)
-	active = true
-	
-func deactivate():
-	active = false
+	# haha funny!!! idx like iidx as in funny beatmania silly game keys
+	# but its a lot like INDEX!!!!!!!!!!!!!!!
+	# GET IT
+	for tick_idx in range(_total_ticks):
+		# duplicate base tick and put it in the tick container
+		var new_tick := $"Tick".duplicate() as TextureRect
+		_tick_container.add_child(new_tick)
+		_tick_container.move_child(new_tick, _tick_container.get_child_count())
+
+		# the number of tick * tick distance * time signature * note speed / 1000 * time signature * 10
+		#new_tick.rect_position = Vector2(tick_idx * _tick_distance * 4 * _speed / 1000 * 40, -64.5)
+		new_tick.rect_position = Vector2(tick_idx * _tick_distance * _speed / 40, -64.5)
+
+
+func _input(event: InputEvent) -> void:
+	# lol
+	if _total_ticks <= _current_tick or not _active or not not (event.is_action_pressed("LeftDon") or event.is_action_pressed("LeftKat") or event.is_action_pressed("RightDon") or event.is_action_pressed("RightKat")):
+		return
+
+	var cur_song_time := _gameplay.music.get_playback_position()
+	# if after slider is hittable
+	if cur_song_time > timing + _length + _gameplay.hit_manager.inaccTiming:
+		deactivate()
+		return
+	# if before slider is hittable
+	if cur_song_time < timing - _gameplay.hit_manager.inaccTiming:
+		return
+
+	# get current tick target
+	_current_tick = int(clamp((cur_song_time - timing) * _tick_distance * 4, 0, _total_ticks))
+
+	_current_tick = int(min(_current_tick, _tick_container.get_child_count() - 1))
+	var tick := _tick_container.get_child(_current_tick) as CanvasItem
+	if tick.visible:
+		print(_current_tick)
+		tick.hide()
+		_gameplay.hit_manager.addScore("roll")
+
+
+func _process(_delta: float) -> void:
+	if _active:
+		var _vel := move_and_slide(Vector2(_speed * -1.9, 0))
+
+
+
+func change_properties(new_timing: float, new_speed: float, new_length: float, new_finisher: bool, beat_length: float) -> void:
+	if _active:
+		push_warning("Attempted to change roll properties after active.")
+		return
+	finisher = new_finisher
+	timing = new_timing
+	_length = new_length
+	_speed = new_speed
+
+	_tick_distance = beat_length / 100
+
+	# length of the roll divided by the distance between ticks
+	# and multiplied by the frequency
+	_total_ticks = int(_length / _tick_distance * 48)
+
+
+func activate() -> void:
+	if _active:
+		push_warning("Attempted to activate roll after active.")
+		return
+	position = Vector2(_speed * timing, 0)
+	for tick_idx in range(_tick_container.get_child_count()):
+		var tick := _tick_container.get_child(tick_idx) as CanvasItem
+		tick.show()
+	_active = true
+
+
+func deactivate() -> void:
+	if not _active:
+		push_warning("Attempted to deactivate roll before active.")
+		return
+	_active = false

--- a/scripts/note_objects/roll.gd
+++ b/scripts/note_objects/roll.gd
@@ -97,8 +97,7 @@ func activate() -> void:
 		return
 	position = Vector2(_speed * timing, 0)
 	for tick_idx in range(_tick_container.get_child_count()):
-		var tick := _tick_container.get_child(tick_idx) as CanvasItem
-		tick.show()
+		(_tick_container.get_child(tick_idx) as CanvasItem).show()
 	_active = true
 
 

--- a/scripts/note_objects/spinner_warn.gd
+++ b/scripts/note_objects/spinner_warn.gd
@@ -34,9 +34,9 @@ func deactivate() -> void:
 	#possibly more laggy honestly
 	var chartSV = get_node("../../../../../ChartLoader").findTiming(timing)
 	var hitsRequired = floor(length / ((chartSV[0] / 60)) * 16)
+	spinner.change_properties(timing, length, hitsRequired)
 	get_parent().add_child(spinner)
 	get_parent().move_child(spinner, 0)
-	spinner.changeProperties(timing, hitsRequired, length)
 	
 	#make self deactive (duh!)
 	modulate = Color(0,0,0,0)


### PR DESCRIPTION
Begins the refactoring process for static typing and fixes spinner starting notes.
- [x] Depends on: #4 

I am pushing this out as I continue to refactor as this contains the first visible gameplay update. [This new logic](https://github.com/zachmanthethird/TaiClone/blob/static-typing/scripts/note_objects/spinner.gd#L24-L29) allows for spinners to start with a kat keypress.

Since this is the first static typing PR, I'll elaborate on this task. Static typing will alleviate any type errors and overall increase our code quality. This can be easily measured by checking [safe lines](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/static_typing.html#safe-lines) in the editor, and thus is my metric for completion:

- `chart_loader.gd`
- [x] `drum_interaction.gd`
- `hit_error.gd`
- `hit_manager.gd`
- `global_settings.gd`
- `global_tools.gd`
- [x] `skin_manager.gd`
- `volume_control.gd`
- `hit_object.gd`
- [x] `note.gd`
- [x] `roll.gd`
- [x] `spinner.gd`
- `spinner_warn.gd`
- [x] `gameplay.gd`
- `gd_script_audio_import.gd`
- `keybind_changer.gd`
- `offset_thingy.gd`
- `resolution_changer.gd`
- `settings_panel.gd`
- `temploadchart.gd`